### PR TITLE
add missing data

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -11,6 +11,7 @@ COPY LICENSE /dist/
 COPY plugin.go /dist/
 COPY plugin.go /dist/
 COPY vendor /dist/
+COPY IP2LOCATION-LITE-DB1.IPV6.BIN /dist/
 
 COPY deploy/install.sh /
 


### PR DESCRIPTION
A regression from Dockerfile cleanup resulted in the geoip data being omitted.
This restores that data.